### PR TITLE
Semantically group labels in preview

### DIFF
--- a/icons/_preview.html
+++ b/icons/_preview.html
@@ -25,17 +25,21 @@
       .tag.inverted {
         color: #333;
       }
+
+      p {
+        margin-top: .5em;
+      }
     </style>
   </head>
   <body>
     <h1>Labels</h1>
 
-    <h3>Default</h3>
+    <h2>Default</h3>
 
-    <p>{{ DEFAULT_ICONS }}</p>
+    {{ DEFAULT_ICONS }}
 
-    <h3>Additional</h3>
+    <h2>Additional</h3>
 
-    <p>{{ ADDITIONAL_ICONS }}</p>
+    {{ ADDITIONAL_ICONS }}
   </body>
 </html>

--- a/icons/preview.html
+++ b/icons/preview.html
@@ -25,239 +25,265 @@
       .tag.inverted {
         color: #333;
       }
+
+      p {
+        margin-top: .5em;
+      }
     </style>
   </head>
   <body>
     <h1>Labels</h1>
 
-    <h3>Default</h3>
+    <h2>Default</h3>
 
-    <p>
-      <span class="tag "
-            title="Something isn't working"
-            style="background-color: #d73a4a">
-        bug
-      </span>
+    
+      <p>
+        <span class="tag "
+              title="Something isn't working"
+              style="background-color: #d73a4a">
+          bug
+        </span>
+       
+        <span class="tag "
+              title="Updates a dependency"
+              style="background-color: #1D76DB">
+          dependencies
+        </span>
+       
+        <span class="tag inverted"
+              title="New feature or request"
+              style="background-color: #FBCA04">
+          enhancement
+        </span>
+       
+        <span class="tag "
+              title="Security related issue"
+              style="background-color: #fc2929">
+          security
+        </span>
+       
+        <span class="tag "
+              title="This issue blocks further progress."
+              style="background-color: #fc2929">
+          blocker
+        </span>
+      </p>
      
-      <span class="tag "
-            title="Updates a dependency"
-            style="background-color: #1D76DB">
-        dependencies
-      </span>
+      <p>
+        <span class="tag inverted"
+              title="infrastructure"
+              style="background-color: #c7def8">
+          infrastructure
+        </span>
+       
+        <span class="tag inverted"
+              title="release"
+              style="background-color: #c7def8">
+          release
+        </span>
+       
+        <span class="tag inverted"
+              title="Improvements or additions to documentation"
+              style="background-color: #c7def8">
+          documentation
+        </span>
+      </p>
      
-      <span class="tag inverted"
-            title="New feature or request"
-            style="background-color: #FBCA04">
-        enhancement
-      </span>
+      <p>
+        <span class="tag inverted"
+              title="Queued in backlog"
+              style="background-color: #F9D0C4">
+          backlog
+        </span>
+       
+        <span class="tag inverted"
+              title="Ready to be worked on"
+              style="background-color: #F9D0C4">
+          ready
+        </span>
+       
+        <span class="tag inverted"
+              title="Currently worked on"
+              style="background-color: #F9D0C4">
+          in progress
+        </span>
+       
+        <span class="tag inverted"
+              title="Review pending"
+              style="background-color: #F9D0C4">
+          needs review
+        </span>
+       
+        <span class="tag inverted"
+              title="Requires integration of upstream change"
+              style="background-color: #F9D0C4">
+          fixed upstream
+        </span>
+      </p>
      
-      <span class="tag "
-            title="Security related issue"
-            style="background-color: #fc2929">
-        security
-      </span>
+      <p>
+        <span class="tag "
+              title="Good for newcomers"
+              style="background-color: #7057ff">
+          good first issue
+        </span>
+       
+        <span class="tag "
+              title="Extra attention is needed"
+              style="background-color: #7057ff">
+          help wanted
+        </span>
+       
+        <span class="tag "
+              title="We rely on a community contribution to improve this."
+              style="background-color: #7057ff">
+          pr welcome
+        </span>
+      </p>
      
-      <span class="tag "
-            title="This issue blocks further progress."
-            style="background-color: #fc2929">
-        blocker
-      </span>
+      <p>
+        <span class="tag "
+              title="Needs further discussion"
+              style="background-color: #cc317c">
+          needs discussion
+        </span>
+       
+        <span class="tag "
+              title="Further information is requested"
+              style="background-color: #cc317c">
+          question
+        </span>
+      </p>
      
-      <span class="tag inverted"
-            title="infrastructure"
-            style="background-color: #c7def8">
-        infrastructure
-      </span>
+      <p>
+        <span class="tag inverted"
+              title="This issue or pull request already exists"
+              style="background-color: #ededed">
+          duplicate
+        </span>
+       
+        <span class="tag inverted"
+              title="This doesn't seem right"
+              style="background-color: #ededed">
+          invalid
+        </span>
+       
+        <span class="tag inverted"
+              title="This will not be worked on"
+              style="background-color: #ededed">
+          wontfix
+        </span>
+      </p>
      
-      <span class="tag inverted"
-            title="release"
-            style="background-color: #c7def8">
-        release
-      </span>
+      <p>
+        <span class="tag inverted"
+              title="Could be cleaned up one day"
+              style="background-color: #C2E0C6">
+          spring cleaning
+        </span>
+      </p>
      
-      <span class="tag inverted"
-            title="Improvements or additions to documentation"
-            style="background-color: #BFD4F2">
-        documentation
-      </span>
-     
-      <span class="tag inverted"
-            title="Queued in backlog"
-            style="background-color: #F9D0C4">
-        backlog
-      </span>
-     
-      <span class="tag inverted"
-            title="Ready to be worked on"
-            style="background-color: #F9D0C4">
-        ready
-      </span>
-     
-      <span class="tag inverted"
-            title="Currently worked on"
-            style="background-color: #F9D0C4">
-        in progress
-      </span>
-     
-      <span class="tag inverted"
-            title="Review pending"
-            style="background-color: #F9D0C4">
-        needs review
-      </span>
-     
-      <span class="tag inverted"
-            title="Requires integration of upstream change"
-            style="background-color: #F9D0C4">
-        fixed upstream
-      </span>
-     
-      <span class="tag "
-            title="Good for newcomers"
-            style="background-color: #7057ff">
-        good first issue
-      </span>
-     
-      <span class="tag "
-            title="Extra attention is needed"
-            style="background-color: #7057ff">
-        help wanted
-      </span>
-     
-      <span class="tag "
-            title="We rely on a community contribution to improve this."
-            style="background-color: #7057ff">
-        pr welcome
-      </span>
-     
-      <span class="tag "
-            title="Needs further discussion"
-            style="background-color: #cc317c">
-        needs discussion
-      </span>
-     
-      <span class="tag "
-            title="Further information is requested"
-            style="background-color: #cc317c">
-        question
-      </span>
-     
-      <span class="tag inverted"
-            title="This issue or pull request already exists"
-            style="background-color: #ededed">
-        duplicate
-      </span>
-     
-      <span class="tag inverted"
-            title="This doesn't seem right"
-            style="background-color: #ededed">
-        invalid
-      </span>
-     
-      <span class="tag inverted"
-            title="This will not be worked on"
-            style="background-color: #ededed">
-        wontfix
-      </span>
-     
-      <span class="tag inverted"
-            title="Could be cleaned up one day"
-            style="background-color: #C2E0C6">
-        spring cleaning
-      </span>
-     
-      <span class="tag inverted"
-            title="channel:support"
-            style="background-color: #eda9f2">
-        channel:support
-      </span>
-     
-      <span class="tag inverted"
-            title="channel:customer"
-            style="background-color: #eda9f2">
-        channel:customer
-      </span>
-    </p>
+      <p>
+        <span class="tag inverted"
+              title="channel:support"
+              style="background-color: #eda9f2">
+          channel:support
+        </span>
+       
+        <span class="tag inverted"
+              title="channel:customer"
+              style="background-color: #eda9f2">
+          channel:customer
+        </span>
+      </p>
+    
 
-    <h3>Additional</h3>
+    <h2>Additional</h3>
 
-    <p>
-      <span class="tag "
-            title="Camunda Platform"
-            style="background-color: #006b75">
-        Camunda Platform
-      </span>
+    
+      <p>
+        <span class="tag "
+              title="Camunda Platform"
+              style="background-color: #006b75">
+          Camunda Platform
+        </span>
+       
+        <span class="tag "
+              title="Camunda Cloud"
+              style="background-color: #006b75">
+          Camunda Cloud
+        </span>
+       
+        <span class="tag "
+              title="BPMN"
+              style="background-color: #006b75">
+          BPMN
+        </span>
+       
+        <span class="tag "
+              title="DMN"
+              style="background-color: #006b75">
+          DMN
+        </span>
+      </p>
      
-      <span class="tag "
-            title="Camunda Cloud"
-            style="background-color: #006b75">
-        Camunda Cloud
-      </span>
+      <p>
+        <span class="tag "
+              title="ux"
+              style="background-color: #0E8A16">
+          ux
+        </span>
+       
+        <span class="tag "
+              title="a11y"
+              style="background-color: #0E8A16">
+          a11y
+        </span>
+       
+        <span class="tag "
+              title="refactoring actions"
+              style="background-color: #0E8A16">
+          refactoring actions
+        </span>
+       
+        <span class="tag "
+              title="developer productivity"
+              style="background-color: #0E8A16">
+          developer productivity
+        </span>
+       
+        <span class="tag "
+              title="import"
+              style="background-color: #0E8A16">
+          import
+        </span>
+      </p>
      
-      <span class="tag "
-            title="BPMN"
-            style="background-color: #006b75">
-        BPMN
-      </span>
-     
-      <span class="tag "
-            title="DMN"
-            style="background-color: #006b75">
-        DMN
-      </span>
-     
-      <span class="tag "
-            title="ux"
-            style="background-color: #0E8A16">
-        ux
-      </span>
-     
-      <span class="tag "
-            title="a11y"
-            style="background-color: #0E8A16">
-        a11y
-      </span>
-     
-      <span class="tag "
-            title="refactoring actions"
-            style="background-color: #0E8A16">
-        refactoring actions
-      </span>
-     
-      <span class="tag "
-            title="developer productivity"
-            style="background-color: #0E8A16">
-        developer productivity
-      </span>
-     
-      <span class="tag "
-            title="import"
-            style="background-color: #0E8A16">
-        import
-      </span>
-     
-      <span class="tag inverted"
-            title="browser:IE"
-            style="background-color: #eb6420">
-        browser:IE
-      </span>
-     
-      <span class="tag inverted"
-            title="browser:Edge"
-            style="background-color: #eb6420">
-        browser:Edge
-      </span>
-     
-      <span class="tag inverted"
-            title="os:Windows"
-            style="background-color: #eb6420">
-        os:Windows
-      </span>
-     
-      <span class="tag inverted"
-            title="os:Linux"
-            style="background-color: #eb6420">
-        os:Linux
-      </span>
-    </p>
+      <p>
+        <span class="tag inverted"
+              title="browser:IE"
+              style="background-color: #eb6420">
+          browser:IE
+        </span>
+       
+        <span class="tag inverted"
+              title="browser:Edge"
+              style="background-color: #eb6420">
+          browser:Edge
+        </span>
+       
+        <span class="tag inverted"
+              title="os:Windows"
+              style="background-color: #eb6420">
+          os:Windows
+        </span>
+       
+        <span class="tag inverted"
+              title="os:Linux"
+              style="background-color: #eb6420">
+          os:Linux
+        </span>
+      </p>
+    
   </body>
 </html>

--- a/labels-additional.yml
+++ b/labels-additional.yml
@@ -2,45 +2,58 @@
 
 - name: Camunda Platform
   color: "006b75"
+  group: domain
 
 - name: Camunda Cloud
   color: "006b75"
+  group: domain
 
 - name: BPMN
   color: "006b75"
+  group: domain
 
 - name: DMN
   color: "006b75"
+  group: domain
 
 
 # theme
 
 - name: ux
   color: "0E8A16"
+  group: theme
 
 - name: a11y
   color: "0E8A16"
+  group: theme
 
 - name: refactoring actions
   color: "0E8A16"
+  group: theme
 
 - name: developer productivity
   color: "0E8A16"
+  group: theme
 
 - name: import
   color: "0E8A16"
+  group: theme
 
 
 # environment
 
 - name: browser:IE
   color: "eb6420"
+  group: environment
 
 - name: browser:Edge
   color: "eb6420"
+  group: environment
 
 - name: os:Windows
   color: "eb6420"
+  group: environment
 
 - name: os:Linux
   color: "eb6420"
+  group: environment

--- a/labels-default.yml
+++ b/labels-default.yml
@@ -3,35 +3,46 @@
 - name: bug
   description: Something isn't working
   color: "d73a4a"
+  group: types
 
 - name: dependencies
   description: Updates a dependency
   color: "1D76DB"
+  group: types
 
 - name: enhancement
   description: New feature or request
   color: "FBCA04"
+  group: types
 
 - name: security
   description: Security related issue
   color: "fc2929"
+  group: types
 
 - name: blocker
   description: This issue blocks further progress.
   color: "fc2929"
+  group: types
+
+
+# misc
 
 - name: infrastructure
   aliases: 
     - maintainance
     - ci
   color: "c7def8"
+  group: misc
 
 - name: release
   color: "c7def8"
+  group: misc
 
 - name: documentation
   description: Improvements or additions to documentation
-  color: "BFD4F2"
+  color: "c7def8"
+  group: misc
 
 
 # states
@@ -39,22 +50,27 @@
 - name: backlog
   description: Queued in backlog
   color: "F9D0C4"
+  group: states
 
 - name: ready
   description: Ready to be worked on
   color: "F9D0C4"
+  group: states
 
 - name: in progress
   description: Currently worked on
   color: "F9D0C4"
+  group: states
 
 - name: needs review
   description: Review pending
   color: "F9D0C4"
+  group: states
 
 - name: fixed upstream
   description: Requires integration of upstream change
   color: "F9D0C4"
+  group: states
 
 
 # generic markers
@@ -66,10 +82,12 @@
     - starter
   description: Good for newcomers
   color: "7057ff"
+  group: contribution
 
 - name: help wanted
   description: Extra attention is needed
   color: "7057ff"
+  group: contribution
 
 - name: pr welcome
   aliases:
@@ -78,37 +96,49 @@
     - pr-welcome
   description: We rely on a community contribution to improve this.
   color: "7057ff"
+  group: contribution
 
 - name: needs discussion
   aliases:
     - needs-discussion
   description: Needs further discussion
   color: "cc317c"
+  group: discovery
 
 - name: question
   description: Further information is requested
   color: "cc317c"
+  group: discovery
 
 - name: duplicate
   description: This issue or pull request already exists
   color: "ededed"
+  group: resolution
 
 - name: invalid
   description: This doesn't seem right
   color: "ededed"
+  group: resolution
 
 - name: wontfix
   aliases:
     - wont fix
   description: This will not be worked on
   color: "ededed"
+  group: resolution
 
 - name: spring cleaning
   description: Could be cleaned up one day
   color: "C2E0C6"
+  group: markers
+
+
+# support
 
 - name: "channel:support"
   color: "eda9f2"
+  group: support
 
 - name: "channel:customer"
   color: "eda9f2"
+  group: support


### PR DESCRIPTION
This wraps up my work on https://github.com/bpmn-io/internal-docs/issues/389 and provides us a solid foundation to improve our labels in the future.

The following labels are now active (semantic grouping in the preview added via this PR):

![image](https://user-images.githubusercontent.com/58601/210614837-5f3864a1-83d2-4731-9cb0-39f6f0f70d8b.png)

----

Closes https://github.com/bpmn-io/internal-docs/issues/389