### PR TITLE
feat: add `needs more information` label

### DIFF
--- a/labels-default.yml
+++ b/labels-default.yml
@@ -89,6 +89,11 @@
   color: "9157ff"
   group: contribution
 
+- name: needs more information
+  description: Requires additional information to be actionable.
+  color: "9157ff"
+  group: contribution
+
 - name: pr welcome
   aliases:
     - pr-maybe


### PR DESCRIPTION
As discussed some time ago we want to separate `help wanted` from `needs more information`.

This way we can better manage stalled issues and close these as won't fix.